### PR TITLE
ST-1021/1022 - Remove Duplicates in Swagger Dashboard, Monitor Dashboard and add headers in Monitor Dashboard

### DIFF
--- a/src/main/java/gov/va/ascent/dashboard/DashboardController.java
+++ b/src/main/java/gov/va/ascent/dashboard/DashboardController.java
@@ -1,8 +1,9 @@
 package gov.va.ascent.dashboard;
 
 import java.io.IOException;
-import java.util.*;
 
+import java.util.Map;
+import java.util.TreeMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 

--- a/src/main/java/gov/va/ascent/dashboard/DashboardController.java
+++ b/src/main/java/gov/va/ascent/dashboard/DashboardController.java
@@ -26,9 +26,9 @@ public class DashboardController {
 
 	private final static Logger LOGGER = LoggerFactory.getLogger(DashboardController.class);
 
-	private static final String REST_API = "REST-API";
-	private static final String APP_TYPE = "appType";
-	private static final String API = "api/";
+	private final static String REST_API = "REST-API";
+	private final static String APP_TYPE = "appType";
+	private final static String API = "api/";
 
 	@Autowired
     private DiscoveryClient discoveryClient;

--- a/src/main/resources/templates/monitor.html
+++ b/src/main/resources/templates/monitor.html
@@ -10,8 +10,9 @@
 <body>
 	<div class="container">
 	<h1>Monitoring Links</h1>
-	<div th:each="gatewayUrl: ${gatewayUrls}">
+	<div th:each="gatewayUrl : ${gatewayUrls}">
 		<table class="table">
+			<h2 th:text="${gatewayUrl.key}"></h2>
 			<thead class="thead-inverse">
 				<tr>
 					<th>ID</th>
@@ -19,47 +20,47 @@
 				</tr>
 			</thead>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/autoconfig|}" th:text="autoconfig"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/autoconfig|}" th:text="autoconfig"></a></td>
 				<td>Displays an auto-configuration report showing all auto-configuration candidates and the reason why they were or were not applied.</td>
 			</tr>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/beans|}" th:text="beans"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/beans|}" th:text="beans"></a></td>
 				<td>Displays a complete list of all the Spring Beans in your application.</td>
 			</tr>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/configprops|}" th:text="configprops"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/configprops|}" th:text="configprops"></a></td>
 				<td>Displays a collated list of all @ConfigurationProperties.</td>
 			</tr>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/dump|}" th:text="dump"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/dump|}" th:text="dump"></a></td>
 				<td>Performs a thread dump.</td>
 			</tr>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/env|}" th:text="env"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/env|}" th:text="env"></a></td>
 				<td>Exposes properties from Spring's ConfigurableEnvironment.</td>
 			</tr>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/health|}" th:text="health"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/health|}" th:text="health"></a></td>
 				<td>Shows application health information (defaulting to a simple OK message).</td>
 			</tr>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/info|}" th:text="info"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/info|}" th:text="info"></a></td>
 				<td>Displays arbitrary application info.</td>
 			</tr>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/metrics|}" th:text="metrics"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/metrics|}" th:text="metrics"></a></td>
 				<td>Shows metrics information for the current application.</td>
 			</tr>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/mappings|}" th:text="mappings"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/mappings|}" th:text="mappings"></a></td>
 				<td>Displays a collated list of all @RequestMapping paths.</td>
 			</tr>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/trace|}" th:text="trace"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/trace|}" th:text="trace"></a></td>
 				<td>Displays trace information (by default the last few HTTP requests).</td>
 			</tr>
 			<tr>
-				<td><a th:href="@{|${gatewayUrl}/loggers|}" th:text="loggers"></a></td>
+				<td><a th:href="@{|${gatewayUrl.value}/loggers|}" th:text="loggers"></a></td>
 				<td>Shows and modifies the configuration of loggers in the application.</td>
 			</tr>
 		</table>

--- a/src/main/resources/templates/swagger.html
+++ b/src/main/resources/templates/swagger.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>Getting Started: Serving Web Content</title>
+    <title>Swagger Dashboard</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <link href="http://cdn.jsdelivr.net/webjars/bootstrap/3.2.0/css/bootstrap.min.css"
           th:href="@{/webjars/bootstrap/3.2.0/css/bootstrap.min.css}"
@@ -13,7 +13,7 @@
 	    <h2>Swagger Dashboard</h2>
 		<ul class="list-group">
 			<li th:each="swaggerApp : ${swaggerApps}" class="list-group-item">
-				<a th:href="${swaggerApp.url}" th:text="${swaggerApp.app}"></a>
+				<a th:href="${swaggerApp.value}" th:text="${swaggerApp.key}"></a>
 			</li>
 	   	 </ul>
 	  </div>


### PR DESCRIPTION
I made some assumptions:

- Every ServiceInstance of a Service will have the same app type. If this is true, then it doesn't require looping through all the service instances for each service. Only the first ServiceInstance is needed to check the app type.
- Every Service will have at least one ServiceInstance. There are some checks to ensure that's the case, but seems like a good assumption.
- The services on the two dashboards should be listed in alphabetical order.
